### PR TITLE
Only encode spaces as + in query params and values

### DIFF
--- a/tests/test.nim
+++ b/tests/test.nim
@@ -89,7 +89,7 @@ block:
 block:
   let test = "http://localhost:8080/p2/foo+and+other+stuff"
   let url = parseUrl(test)
-  assert url.paths == @["p2", "foo and other stuff"]
+  assert url.paths == @["p2", "foo+and+other+stuff"]
   assert $url == "http://localhost:8080/p2/foo+and+other+stuff"
 
 block:
@@ -103,7 +103,7 @@ block:
   let test = "http://localhost:8080/p2/#foo+and+other+stuff"
   let url = parseUrl(test)
   assert url.paths == @["p2", ""]
-  assert url.fragment == "foo and other stuff"
+  assert url.fragment == "foo+and+other+stuff"
   assert $url == "http://localhost:8080/p2/#foo+and+other+stuff"
 
 block:


### PR DESCRIPTION
As per [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986), spaces in the path portion of the URL must be encoded as `%20` and **never** `+`. `+` must be left as-is (or optionally encoded as `%2b`).

Spaces _can_ be encoded as `+` or `%20` in content with the type `application/x-www-form-urlencoded`, which as per [RFC 1866](https://www.rfc-editor.org/rfc/rfc1866) is the content encoding for the query part of the URL **only** - it is not applicable for the path part of the URL.

There's no specification detailing how spaces in fragments should be encoded, but I checked how Chromium and Firefox handles it - both browsers encode spaces as `%20` and treat `+` as-is. That means, if a DOM element has an ID of `test 1`, then the URL fragment `#test 1` scrolls to it, but the fragment `#test+1` does not. `#test+1` only scrolls to the element if it has the literal id value `test+1`. Surprisingly, the id value `test%201` also works for with the URL fragment `#test 1` in both browsers.

Firefox displays fragments with spaces in them literally in the URL bar (`http://domain.tld/#test 1`), while Chromium transforms all entered spaces to `%20` (`http://domain.tld/#test%201`).

This PR introduces new procedures `encodeQueryComponent` and `decodeQueryComponent`, which behave as `encodeUrlComponent` and `decodeUrlComponent` accordingly do currently. `encodeUrlComponent` and `decodeUrlComponent` have been modified to unconditionally encode spaces as `%20`, and leave `+` as-is (not encoded). Procedures which handle encoding and decoding full URLs have been updated to use the correct procedures when encoding or decoding URL parts. Tests have also been updated to reflect this "new" behaviour.

This PR fixes issue #5 and subsequently https://github.com/treeform/puppy/issues/80.